### PR TITLE
Quick-and-dirty VS2013 support, to get us working again.

### DIFF
--- a/install_deps_vs2013.cmake
+++ b/install_deps_vs2013.cmake
@@ -1,0 +1,22 @@
+include("${CMAKE_CURRENT_LIST_DIR}/scripts/helpers.cmake")
+
+set(INSTALL_DIR "${ROOT_DIR}/install")
+set(SERVER "https://github.com/ethereum/cpp-dependencies/releases/download/vc120/")
+
+function(download_and_install PACKAGE_NAME)
+    download_and_unpack("${SERVER}${PACKAGE_NAME}-x64.tar.gz" ${ROOT_DIR}/old_layout)
+	file(COPY ${ROOT_DIR}/old_layout/${PACKAGE_NAME}/x64 DESTINATION ${INSTALL_DIR})
+endfunction(download_and_install)
+
+
+download_and_install("boost-1.55.0")
+download_and_install("cryptopp-5.6.2")
+download_and_install("curl-7.4.2")
+download_and_install("json-rpc-cpp-0.5.0")
+download_and_install("jsoncpp-1.6.2")
+download_and_install("leveldb-1.2")
+download_and_install("llvm-3.7.0")
+download_and_install("microhttpd-0.9.2")
+download_and_install("miniupnpc-1.9")
+download_and_install("OpenCL_ICD-1")
+#download_and_install("qt-5.5.1")   # Broken layout?


### PR DESCRIPTION
The layouts for the old .TAR.GZ files are not great, so we have to copy them
Made a new LLVM file, which is a copy of the one from build.ethereum.org, but with the massive debug LIBs stripped.
